### PR TITLE
Oops I was running the server wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you can start working with Yari, you need to:
     if translations are desired:
 
     ```
-    git clone https://github.com/pommicket/yari
+    git clone https://github.com/MDN-Community-Fork/yari
     git clone https://github.com/mdn/content
     # git clone https://github.com/mdn/translated-content
     ```
@@ -103,22 +103,52 @@ original yari repo):
 When you embark on making a change, do it on a new branch, for example
 `git checkout -b my-new-branch`.
 
-## Run server in production mode
+## Hosting a production build of MDN web docs
 
-Annoying that mdn/yari doesn't include this information.
+First run
 
 ```
-export NODE_OPTIONS='--max-old-space-size=4096' # max megabytes of memory, if it's too low compilation may fail
 yarn build:prepare
 yarn build:dist
-# yarn build # (optional) this takes a LONG time but the first request to a page will be faster
-yarn start:server
+yarn build
 ```
 
-If you only make changes to the source files in the `server` directory, you just
-need to run `yarn build:dist` and restart the server (in particular, don't run
-`yarn build:prepare` again since it'll delete all the stuff that `yarn build`
-built).
+If the build fails with an error message about running out of memory, try
+setting the environment variable `NODE_OPTIONS='--max-old-space-size=4096'
+(replacing 4096 with a "safe" maximum memory usage in megabytes).
+
+Then you can just host the directory `client/build` using a static server.
+However, MDN has played loose with capitalization, so you will need to set your
+server to be case insensitive.
+
+For example, you can host MDN web docs on port 5042 using Apache2 as follows:
+
+```
+# (as root from the directory of yari)
+rm -rf /var/www/mdn
+cp -r client/build /var/www/mdn
+a2enmod speling # (sic)
+cat <<EOF > /etc/apache2/sites-available/mdn-web-docs.conf
+<VirtualHost *:5042>
+    DocumentRoot /var/www/mdn
+    ErrorLog /var/log/apache2/error.log
+
+    <IfModule mod_speling.c>
+        CheckSpelling On
+        CheckCaseOnly On
+    </IfModule>
+</VirtualHost>
+<Directory /var/www/mdn>
+    RemoveHandler .var
+</Directory>
+EOF
+ln -sf ../sites-available/mdn-web-docs.conf /etc/apache2/sites-enabled/mdn-web-docs.conf
+```
+
+Then add `Listen 5042` to `/etc/apache2/ports.conf` next to `Listen 80`, and run
+`systemctl restart apache2`.
+
+Now you can visit `http://localhost:5042` to view MDN web docs offline.
 
 ## License
 

--- a/kumascript/src/live-sample.ts
+++ b/kumascript/src/live-sample.ts
@@ -132,6 +132,10 @@ export async function buildLiveSamplePages(uri, title, $, rawBody) {
         }
         sampleData.sampleTitle = `${title} - ${id} - code sample`;
         result.html = liveSampleTemplate(sampleData);
+        // pommicket: make every iframe point to the same runner.html file
+        // because there's only one actual runner.html in the build output.
+        // not sure why MDN decided to give each iframe its own /some/long/path/runner.html
+        $(iframe).attr("src", `/runner.html?id=${iframeSlug}`);
         return result;
       }),
   ]);

--- a/server/middlewares.ts
+++ b/server/middlewares.ts
@@ -17,7 +17,6 @@ const slugRewrite = (req, res, next) => {
   // pommicket:
   // mdn is wrong. the font files are not all lowercase.
   // neither is main.js.blablabla.LICENSE.txt
-  // i guess they run windows on their servers? fucked up
   if (!req.url.endsWith(".woff2") && req.url.indexOf("LICENSE") === -1)
     req.url = req.url.toLowerCase();
   next();

--- a/server/search-index.ts
+++ b/server/search-index.ts
@@ -10,6 +10,7 @@ import { SearchIndex } from "../build/index.js";
 import { isValidLocale } from "../libs/locale-utils/index.js";
 
 interface DocAttributes {
+  title: string;
   locale: string;
   slug: string;
 }
@@ -37,9 +38,6 @@ function getSearchIndex(localeLC) {
 }
 
 function getSearchIndexes() {
-  // I can't imagine MDN actually does all this work on every request,
-  // but that seems to be the case.
-  // on my crappy server it takes 8 whole seconds so caching is sorely needed.
   const map: Map<string, SearchIndex> = new Map();
 
   for (const locale of VALID_LOCALES.keys()) {
@@ -55,6 +53,9 @@ function getSearchIndexes() {
   return map;
 }
 
+// building the search index can take some time,
+// so we cache it. mdn/yari opts not to do this because
+// if you're editing the site the cache can become stale.
 const searchIndexes: Map<string, SearchIndex> = getSearchIndexes();
 
 export async function searchIndexRoute(req, res) {


### PR DESCRIPTION
Turns out (I'm pretty sure) that you're supposed to run `yarn build` then host the `client/build` directory statically.
But like, you also need to handle case insensitivity because MDN has some weird stuff about that?
Like fun fact this link works fine: https://developer.mozilla.org/EN-US/dOcs/wEb/aPi/htmlCollecTIon
Also `runner.html` links wouldn't work unless you added some extra stuff to handle it... uhh I don't know what mozilla is doing.

## Summary


### Problem

- Running the server through `yarn start:server` is more resource intensive compared to just serving static files.
- Also there was a type error in `search-index.ts` which was only being generated the first time the file was compiled (like it didn't reoccur even after touching it and deleting the output js file ... (probably some weird typescript thing)).

### Solution

- Updated README with new instructions about how to host the docs
- Cleared up some old comments (in which I was very confused about why MDN did things the way they did but it makes sense now)
- Hacked in a fix so that you don't need special stuff on the server to handle runner.html being used under multiple URLs (e.g. https://live.mdnplay.dev/en-US/docs/a/runner.html and https://live.mdnplay.dev/en-US/docs/hmtgf/runner.html and https://live.mdnplay.dev/en-US/docs/literally-anything-else/runner.html all give you the exact same file)
- Fixed the type error