### PR TITLE
Make the content origin configurable

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,4 +1,5 @@
 GITHUB_ORG=MDN-Community-Fork
+CONTENT_ORIGIN=https://mdn.pommicket.com
 CONTENT_ROOT=../content/files
 #CONTENT_TRANSLATED_ROOT=../translated-content/files
 #CONTRIBUTOR_SPOTLIGHT_ROOT=../mdn-contributor-spotlight/contributors

--- a/build/check-images.ts
+++ b/build/check-images.ts
@@ -12,6 +12,8 @@ import { findMatchesInText } from "./matches-in-text.js";
 import * as cheerio from "cheerio";
 import { Doc } from "../libs/types/document.js";
 
+import "dotenv/config";
+
 const { default: sizeOf } = imagesize;
 
 /**
@@ -110,7 +112,7 @@ export function checkImageReferences(
             explanation: "Insecure URL",
             suggestion: absoluteURL.toString(),
           });
-        } else if (absoluteURL.hostname === "developer.mozilla.org") {
+        } else if (absoluteURL.origin === process.env.CONTENT_ORIGIN) {
           // Suppose they typed this:
           // <img src=https://developer.mozilla.org/en-US/docs/Foo/img.png>
           // and the current page you're on is /en-US/docs/Foo then the

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -15,6 +15,8 @@ import * as cheerio from "cheerio";
 import { Doc } from "../../libs/types/document.js";
 import { Flaw } from "./index.js";
 
+import "dotenv/config";
+
 function findMatchesInMarkdown(rawContent: string, href: string) {
   const matches = [];
   visit(fromMarkdown(rawContent), "link", (node: any) => {
@@ -225,7 +227,7 @@ export function getBrokenLinksFlaws(
       // Note! If it's not known that the URL's domain can be turned into https://
       // we do nothing here. No flaw. It's unfortunate that we still have http://
       // links in our content but that's a reality of MDN being 15+ years old.
-    } else if (href.startsWith("https://developer.mozilla.org/")) {
+    } else if (href.startsWith(process.env.CONTENT_ORIGIN)) {
       // It might be a working 200 OK link but the link just shouldn't
       // have the full absolute URL part in it.
       const absoluteURL = new URL(href);

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -1,10 +1,12 @@
+import "dotenv/config";
+
 export function makeSitemapXML(locale, docs) {
   // Based on https://support.google.com/webmasters/answer/183668?hl=en
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     ...docs.map((doc) => {
-      const loc = `<loc>https://developer.mozilla.org/${locale}/docs/${doc.slug}</loc>`;
+      const loc = `<loc>${process.env.CONTENT_ORIGIN}/${locale}/docs/${doc.slug}</loc>`;
       const modified = doc.modified
         ? `<lastmod>${doc.modified.toString().split("T")[0]}</lastmod>`
         : "";
@@ -23,7 +25,7 @@ export function makeSitemapIndexXML(pathnames) {
     ...pathnames.map((pathname) => {
       return (
         "<sitemap>" +
-        `<loc>https://developer.mozilla.org${pathname}</loc>` +
+        `<loc>https://${process.env.CONTENT_ORIGIN}${pathname}</loc>` +
         `<lastmod>${new Date().toISOString().split("T")[0]}</lastmod>` +
         "</sitemap>"
       );

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -20,6 +20,8 @@ import { FileAttachment } from "../content/index.js";
 import { spawnSync } from "node:child_process";
 import { BLOG_ROOT } from "../libs/env/index.js";
 
+import "dotenv/config";
+
 const { default: imageminPngquant } = imageminPngquantPkg;
 
 export function humanFileSize(size: number) {
@@ -225,7 +227,7 @@ export function injectLoadingLazyAttributes($) {
 export function postProcessExternalLinks($) {
   $("a[href^=http]").each((i, element) => {
     const $a = $(element);
-    if ($a.attr("href").startsWith("https://developer.mozilla.org")) {
+    if ($a.attr("href").startsWith(process.env.CONTENT_ORIGIN)) {
       // This should have been removed since it's considered a flaw.
       // But we haven't applied all fixable flaws yet and we still have to
       // support translated content which is quite a long time away from

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -156,7 +156,7 @@ export default function BrowserCompatibilityTable({
     )
       .replace(/\$QUERY_ID/g, query)
       .trim();
-    sp.set("mdn-url", `https://developer.mozilla.org${location.pathname}`);
+    sp.set("mdn-url", `${process.env.CONTENT_ORIGIN}${location.pathname}`);
     sp.set("metadata", metadata);
     sp.set("title", `${query} - <SUMMARIZE THE PROBLEM>`);
     sp.set("template", "data-problem.yml");

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -1,5 +1,4 @@
 import { Doc } from "../../../libs/types/document";
-import * as dotenv from "dotenv";
 
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
@@ -63,7 +62,7 @@ const METADATA_TEMPLATE = `
 <summary>Page report details</summary>
 
 * Folder: \`$FOLDER\`
-* MDN URL: https://developer.mozilla.org$PATHNAME
+* MDN URL: ${process.env.CONTENT_ORIGIN}$PATHNAME
 * GitHub URL: $GITHUB_URL
 * Last commit: $LAST_COMMIT_URL
 * Document last modified: $DATE
@@ -107,7 +106,7 @@ function NewIssueOnGitHubLink({
       ? `page-report-${locale.toLowerCase()}.yml`
       : "page-report.yml"
   );
-  sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
+  sp.set("mdn-url", `${process.env.CONTENT_ORIGIN}${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
 
   url.search = sp.toString();

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -79,7 +79,7 @@ export function EditActions({ source }: { source: Source }) {
 
       <li>
         <a
-          href={`https://developer.mozilla.org/${locale}/docs/${slug}`}
+          href={`${process.env.CONTENT_ORIGIN}/${locale}/docs/${slug}`}
           className="button"
         >
           View on MDN

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -8,6 +8,8 @@ import { HydrationData } from "../libs/types/hydration";
 import { DEFAULT_LOCALE } from "../libs/constants";
 import { ALWAYS_ALLOW_ROBOTS, BUILD_OUT_ROOT, BASE_URL } from "../libs/env";
 
+import "dotenv/config";
+
 const dirname = path.dirname(fileURLToPath(new URL(".", import.meta.url)));
 
 // When there are multiple options for a given language, this gives the
@@ -212,7 +214,9 @@ export default function render(
         translations.push(
           `<link rel="alternate" title="${htmlEscape(
             translation.title
-          )}" href="https://developer.mozilla.org${translationURL}" hreflang="${getHrefLang(
+          )}" href="https://${
+            process.env.CONTENT_ORIGIN
+          }${translationURL}" hreflang="${getHrefLang(
             translation.locale,
             allLocales
           )}"/>`

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import cheerio from "cheerio";
 import imagesize from "image-size";
 
+import "dotenv/config";
+
 const { default: sizeOf } = imagesize;
 
 import type {
@@ -114,9 +116,9 @@ test("content built foo page", () => {
   expect($("img").attr("height")).toBe("250");
 
   // Every page, should have a `link[rel=canonical]` whose `href` always
-  // starts with 'https://developer.mozilla.org' and ends with doc's URL.
+  // starts with the value of $CONTENT_ORIGIN and ends with doc's URL.
   expect($("link[rel=canonical]").attr("href")).toBe(
-    `https://developer.mozilla.org${doc.mdn_url}`
+    `${process.env.CONTENT_ORIGIN}${doc.mdn_url}`
   );
 
   expect($('meta[name="robots"]').attr("content")).toBe("index, follow");
@@ -138,8 +140,8 @@ test("content built foo page", () => {
   // The domain is hardcoded because the URL needs to be absolute and when
   // building static assets for Dev or Stage, you don't know what domain is
   // going to be used.
-  expect(toEnUSURL).toBe("https://developer.mozilla.org/en-US/docs/Web/Foo");
-  expect(toFrURL).toBe("https://developer.mozilla.org/fr/docs/Web/Foo");
+  expect(toEnUSURL).toBe(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/Foo`);
+  expect(toFrURL).toBe(`${process.env.CONTENT_ORIGIN}/fr/docs/Web/Foo`);
 
   // The h4 heading in there has its ID transformed to lowercase
   expect($("main h4").attr("id")).toBe($("main h4").attr("id").toLowerCase());
@@ -600,14 +602,14 @@ test("broken links flaws", () => {
   expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(10);
   expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(13);
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob").suggestion
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob");
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob#Anchor")
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`)
       .suggestion
   ).toBe("/en-US/docs/Web/API/Blob#Anchor");
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob?a=b")
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`)
       .suggestion
   ).toBe("/en-US/docs/Web/API/Blob?a=b");
   expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
@@ -659,14 +661,14 @@ test("broken links markdown flaws", () => {
   expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(9);
   expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(1);
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob").suggestion
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob");
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob#Anchor")
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`)
       .suggestion
   ).toBe("/en-US/docs/Web/API/Blob#Anchor");
   expect(
-    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob?a=b")
+    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`)
       .suggestion
   ).toBe("/en-US/docs/Web/API/Blob?a=b");
   expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
@@ -1017,7 +1019,7 @@ test("image flaws kitchen sink", () => {
   expect(flaw.column).toBe(13);
 
   flaw = map.get(
-    "https://developer.mozilla.org/en-US/docs/Web/Images/screenshot.png"
+    `${process.env.CONTENT_ORIGIN}/en-US/docs/Web/Images/screenshot.png`
   );
   expect(flaw.explanation).toBe("Unnecessarily absolute URL");
   expect(flaw.suggestion).toBe("screenshot.png");

--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -8,9 +8,11 @@ import fs from "node:fs";
 import { VALID_LOCALES } from "../libs/constants/index.js";
 import { ALWAYS_ALLOW_ROBOTS } from "../libs/env/index.js";
 
+import "dotenv/config";
+
 const ALLOW_TEXT = `
 User-agent: *
-Sitemap: https://developer.mozilla.org/sitemap.xml
+Sitemap: ${process.env.CONTENT_ORIGIN}/sitemap.xml
 
 Disallow: /api/
 Disallow: /*/files/


### PR DESCRIPTION
This change makes it possible to configure the origin (domain) for hosting/serving the project’s content.

There are at least a couple of places where it’s still not completely configurable:

- https://github.com/MDN-Community-Fork/yari/blob/6c2f392212137b9623306bec520d7690b27cab91/libs/env/index.js#L161-L162
- https://github.com/MDN-Community-Fork/yari/blob/6c2f392212137b9623306bec520d7690b27cab91/client/src/env.ts#L47-L48

…but I don’t yet understand what the purpose of the relevant code there is — that is, I don’t yet know what `PROXY_HOSTNAME` is used for, and don’t yet fully understand what `REACT_APP_KUMA_HOST`/`KUMA_HOST` is used for. So this leaves those unchanged for now.
