### PR TITLE
Create Nix flake with a development shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ Before you can start working with Yari, you need to:
 <!-- markdownlint-disable list-marker-space -->
 
 1.  Install [git](https://git-scm.com/), [Node.js](https://nodejs.org), and
-    [Yarn 1](https://classic.yarnpkg.com/en/docs/install).
+    [Yarn 1](https://classic.yarnpkg.com/en/docs/install). Alternatively, if you
+    have [Nix](https://nixos.org) installed on your system, you can use the dev
+    shell provided in the `flake.nix` file at the root of this repo with
+    `nix develop`, to quickly set up an environment with all of the required
+    tools. If you haven't set up Nix to use flakes yet, check the
+    [NixOS Wiki](https://nixos.wiki/wiki/Flakes#Enable_flakes) for instructions.
 
 1.  Clone this repository, as well as the MDN
     [content](https://github.com/mdn/content) repository and the MDN

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689047559,
+        "narHash": "sha256-s3xILs1+Hh4z8zudSnbOz5xM7ltzpg4WZ952ea7OlZ0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a187ec43efbeec0f3be6f9d13a6836fcbb914a9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      devShell = pkgs.mkShell {
+        name = "yari-devshell";
+
+        nativeBuildInputs = with pkgs; [
+          # Nodejs and JS dev tools
+          nodejs
+          yarn
+          nodePackages.typescript-language-server
+          nodePackages.vscode-css-languageserver-bin
+          nodePackages.vscode-html-languageserver-bin
+
+          # Required for building gifsicle and mozjpeg node packages
+          autoconf
+          automake
+          libtool
+          nasm
+          pkg-config
+
+          # Other tools
+          git
+        ];
+      };
+    });
+}


### PR DESCRIPTION
Added a simple [Nix](https://nixos.org/) flake with a development shell defined. This development shell contains all the tools that should be required to start developing in this repo. Useful to get quickly up and started without having to set everything up manually (other than Nix, of course).

Also edited the README to contain some directions on how to utilize the Nix development shell to get setup.