### PR TITLE
clean up usages of `GITHUB_ORG`, `CONTENT_ORIGIN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fork of Yari which removes AI help "features".
 
-You can view it on the Web here: https://mdn.pommicket.com
+You can view it on the Web at [https://webdocs.dev](https://webdocs.dev)
 
 ## Quickstart
 

--- a/build/check-images.ts
+++ b/build/check-images.ts
@@ -8,11 +8,10 @@ import imagesize from "image-size";
 
 import { Document, FileAttachment } from "../content/index.js";
 import { FLAW_LEVELS, DEFAULT_LOCALE } from "../libs/constants/index.js";
+import { CONTENT_ORIGIN } from "../libs/env/index.js";
 import { findMatchesInText } from "./matches-in-text.js";
 import * as cheerio from "cheerio";
 import { Doc } from "../libs/types/document.js";
-
-import "dotenv/config";
 
 const { default: sizeOf } = imagesize;
 
@@ -112,7 +111,7 @@ export function checkImageReferences(
             explanation: "Insecure URL",
             suggestion: absoluteURL.toString(),
           });
-        } else if (absoluteURL.origin === process.env.CONTENT_ORIGIN) {
+        } else if (absoluteURL.origin === CONTENT_ORIGIN) {
           // Suppose they typed this:
           // <img src=https://developer.mozilla.org/en-US/docs/Foo/img.png>
           // and the current page you're on is /en-US/docs/Foo then the

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -13,9 +13,8 @@ import {
 import { isValidLocale } from "../../libs/locale-utils/index.js";
 import * as cheerio from "cheerio";
 import { Doc } from "../../libs/types/document.js";
+import { CONTENT_ORIGIN } from "../../libs/env/index.js";
 import { Flaw } from "./index.js";
-
-import "dotenv/config";
 
 function findMatchesInMarkdown(rawContent: string, href: string) {
   const matches = [];
@@ -227,7 +226,7 @@ export function getBrokenLinksFlaws(
       // Note! If it's not known that the URL's domain can be turned into https://
       // we do nothing here. No flaw. It's unfortunate that we still have http://
       // links in our content but that's a reality of MDN being 15+ years old.
-    } else if (href.startsWith(process.env.CONTENT_ORIGIN)) {
+    } else if (href.startsWith(CONTENT_ORIGIN)) {
       // It might be a working 200 OK link but the link just shouldn't
       // have the full absolute URL part in it.
       const absoluteURL = new URL(href);

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -9,8 +9,6 @@ import got from "got";
 
 import { m2h } from "../markdown/index.js";
 
-import * as dotenv from "dotenv";
-
 import {
   VALID_LOCALES,
   MDN_PLUS_TITLE,
@@ -21,6 +19,7 @@ import {
   CONTENT_TRANSLATED_ROOT,
   CONTRIBUTOR_SPOTLIGHT_ROOT,
   BUILD_OUT_ROOT,
+  GITHUB_ORG,
 } from "../libs/env/index.js";
 import { isValidLocale } from "../libs/locale-utils/index.js";
 import { DocFrontmatter, NewsItem } from "../libs/types/document.js";
@@ -31,8 +30,6 @@ import { getSlugByBlogPostUrl, splitSections } from "./utils.js";
 import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
-
-export const GITHUB_ORG = process.env.GITHUB_ORG;
 
 const FEATURED_ARTICLES = [
   "blog/regular-expressions-reference-updates/",

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -7,6 +7,7 @@ import { FeatureRow } from "./feature-row";
 import { Headers } from "./headers";
 import { Legend } from "./legend";
 import { listFeatures } from "./utils";
+import { CONTENT_ORIGIN } from "../../../env";
 
 // Note! Don't import any SCSS here inside *this* component.
 // It's done in the component that lazy-loads this component.
@@ -156,7 +157,7 @@ export default function BrowserCompatibilityTable({
     )
       .replace(/\$QUERY_ID/g, query)
       .trim();
-    sp.set("mdn-url", `${process.env.CONTENT_ORIGIN}${location.pathname}`);
+    sp.set("mdn-url", `${CONTENT_ORIGIN}${location.pathname}`);
     sp.set("metadata", metadata);
     sp.set("title", `${query} - <SUMMARIZE THE PROBLEM>`);
     sp.set("template", "data-problem.yml");

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -1,4 +1,5 @@
 import { Doc } from "../../../libs/types/document";
+import { GITHUB_ORG, CONTENT_ORIGIN } from "../env";
 
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
@@ -24,7 +25,7 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       </ul>
       Want to get more involved?{" "}
       <a
-        href={`https://github.com/${process.env.GITHUB_ORG}/content/blob/main/CONTRIBUTING.md`}
+        href={`https://github.com/${GITHUB_ORG}/content/blob/main/CONTRIBUTING.md`}
         title={`This will take you to our contribution guidelines on GitHub.`}
         target="_blank"
         rel="noopener noreferrer"
@@ -62,7 +63,7 @@ const METADATA_TEMPLATE = `
 <summary>Page report details</summary>
 
 * Folder: \`$FOLDER\`
-* MDN URL: ${process.env.CONTENT_ORIGIN}$PATHNAME
+* MDN URL: ${CONTENT_ORIGIN}$PATHNAME
 * GitHub URL: $GITHUB_URL
 * Last commit: $LAST_COMMIT_URL
 * Document last modified: $DATE
@@ -93,20 +94,19 @@ function NewIssueOnGitHubLink({
 }) {
   const { locale } = doc;
   const url = new URL("https://github.com/");
-  const github_org = process.env.GITHUB_ORG;
   const sp = new URLSearchParams();
 
   url.pathname =
     locale !== "en-US"
-      ? `/${github_org}/translated-content/issues/new`
-      : `/${github_org}/content/issues/new`;
+      ? `/${GITHUB_ORG}/translated-content/issues/new`
+      : `/${GITHUB_ORG}/content/issues/new`;
   sp.set(
     "template",
     locale !== "en-US"
       ? `page-report-${locale.toLowerCase()}.yml`
       : "page-report.yml"
   );
-  sp.set("mdn-url", `${process.env.CONTENT_ORIGIN}${doc.mdn_url}`);
+  sp.set("mdn-url", `${CONTENT_ORIGIN}${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
 
   url.search = sp.toString();

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { WRITER_MODE_HOSTNAMES } from "../../env";
+import { WRITER_MODE_HOSTNAMES, CONTENT_ORIGIN } from "../../env";
 import { Source } from "../../../../libs/types/document";
 
 import "./edit-actions.scss";
@@ -78,10 +78,7 @@ export function EditActions({ source }: { source: Source }) {
       )}
 
       <li>
-        <a
-          href={`${process.env.CONTENT_ORIGIN}/${locale}/docs/${slug}`}
-          className="button"
-        >
+        <a href={`${CONTENT_ORIGIN}/${locale}/docs/${slug}`} className="button">
           View on MDN
         </a>
       </li>

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -50,6 +50,10 @@ export const KUMA_HOST =
 export const PLAYGROUND_BASE_HOST =
   process.env.REACT_APP_PLAYGROUND_BASE_HOST || "mdnplay.dev";
 
+export const GITHUB_ORG = process.env.GITHUB_ORG || "mdn";
+export const CONTENT_ORIGIN =
+  process.env.CONTENT_ORIGIN || "https://developer.mozilla.org";
+
 export const PLUS_IS_ENABLED = Boolean(
   JSON.parse(process.env.REACT_APP_ENABLE_PLUS || "false")
 );

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -4,7 +4,7 @@ import { useLocation } from "react-router-dom";
 
 import { ReactComponent as MDNLogo } from "../../../assets/mdn-footer-logo.svg";
 import { ReactComponent as MozLogo } from "../../../assets/moz-logo.svg";
-import { PLUS_IS_ENABLED } from "../../../env";
+import { PLUS_IS_ENABLED, GITHUB_ORG } from "../../../env";
 const DARK_NAV_ROUTES = [/\/plus\/?$/i];
 
 export function Footer() {
@@ -35,7 +35,7 @@ export function Footer() {
             <li>
               <a
                 className="icon icon-github-mark-small"
-                href="https://github.com/mdn/"
+                href={`https://github.com/${GITHUB_ORG}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -29,7 +29,7 @@ various places, and is used to fetch recent contributions (see
 
 #### Default: `https://developer.mozilla.org`
 
-The URL where the docs are being hosted.
+The Origin (scheme+host+port, with no trailing slash) URL where the docs are being hosted.
 
 ## Builder
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -16,6 +16,21 @@ the ability to go from viewing a rendered document to opening the source in your
 preferred editor. It's needed for the "Edit this page in your editor" button to
 work.
 
+### `GITHUB_ORG`
+
+#### Default: `mdn`
+
+The GitHub user or organization which hosts the docs. It will be linked to in
+various places, and is used to fetch recent contributions (see
+`fetchRecentContributions` in `build/spas.ts`). It should have the repositories
+`yari`, `content`, and `translated-content`.
+
+### `CONTENT_ORIGIN`
+
+#### Default: `https://developer.mozilla.org`
+
+The URL where the docs are being hosted.
+
 ## Builder
 
 For the builder, a lot of environment variables can be overridden with CLI

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -30,3 +30,5 @@ export const OFFLINE_CONTENT: boolean;
 export const FAKE_V1_API: boolean;
 export const SENTRY_DSN_BUILD: string;
 export const SAMPLE_SIGN_KEY: Buffer;
+export const GITHUB_ORG: string;
+export const CONTENT_ORIGIN: string;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -82,7 +82,9 @@ export const CONTRIBUTOR_SPOTLIGHT_ROOT = correctContentPathFromEnv(
 
 export const BLOG_ROOT = correctContentPathFromEnv("BLOG_ROOT");
 
-export const GITHUB_ORG = process.env.GITHUB_ORG;
+export const GITHUB_ORG = process.env.GITHUB_ORG || "mdn";
+export const CONTENT_ORIGIN =
+  process.env.CONTENT_ORIGIN || "https://developer.mozilla.org";
 
 // This makes it possible to know, give a root folder, what is the name of
 // the repository on GitHub.
@@ -97,7 +99,7 @@ export const REPOSITORY_URLS = {
 export const ROOTS = [CONTENT_ROOT];
 if (CONTENT_TRANSLATED_ROOT) {
   ROOTS.push(CONTENT_TRANSLATED_ROOT);
-  REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = `${GITHUB_ORG}translated-content`;
+  REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = `${GITHUB_ORG}/translated-content`;
 }
 
 function correctContentPathFromEnv(envVarName) {

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -4,8 +4,6 @@ import path from "node:path";
 import cheerio from "cheerio";
 import imagesize from "image-size";
 
-import "dotenv/config";
-
 const { default: sizeOf } = imagesize;
 
 import type {
@@ -14,6 +12,8 @@ import type {
   ProseSection,
   SpecificationsSection,
 } from "../../libs/types/document.js";
+
+import { CONTENT_ORIGIN } from "../../libs/env/index.js";
 
 const buildRoot = path.join("client", "build");
 
@@ -118,7 +118,7 @@ test("content built foo page", () => {
   // Every page, should have a `link[rel=canonical]` whose `href` always
   // starts with the value of $CONTENT_ORIGIN and ends with doc's URL.
   expect($("link[rel=canonical]").attr("href")).toBe(
-    `${process.env.CONTENT_ORIGIN}${doc.mdn_url}`
+    `${CONTENT_ORIGIN}${doc.mdn_url}`
   );
 
   expect($('meta[name="robots"]').attr("content")).toBe("index, follow");
@@ -140,8 +140,8 @@ test("content built foo page", () => {
   // The domain is hardcoded because the URL needs to be absolute and when
   // building static assets for Dev or Stage, you don't know what domain is
   // going to be used.
-  expect(toEnUSURL).toBe(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/Foo`);
-  expect(toFrURL).toBe(`${process.env.CONTENT_ORIGIN}/fr/docs/Web/Foo`);
+  expect(toEnUSURL).toBe(`${CONTENT_ORIGIN}/en-US/docs/Web/Foo`);
+  expect(toFrURL).toBe(`${CONTENT_ORIGIN}/fr/docs/Web/Foo`);
 
   // The h4 heading in there has its ID transformed to lowercase
   expect($("main h4").attr("id")).toBe($("main h4").attr("id").toLowerCase());
@@ -601,16 +601,14 @@ test("broken links flaws", () => {
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
   expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(10);
   expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(13);
+  expect(map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion).toBe(
+    "/en-US/docs/Web/API/Blob"
+  );
   expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion
-  ).toBe("/en-US/docs/Web/API/Blob");
-  expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`)
-      .suggestion
+    map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob#Anchor");
   expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`)
-      .suggestion
+    map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob?a=b");
   expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
     "/en-US/docs/Web/API/Blob"
@@ -660,16 +658,14 @@ test("broken links markdown flaws", () => {
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
   expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(9);
   expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(1);
+  expect(map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion).toBe(
+    "/en-US/docs/Web/API/Blob"
+  );
   expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob`).suggestion
-  ).toBe("/en-US/docs/Web/API/Blob");
-  expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`)
-      .suggestion
+    map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob#Anchor`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob#Anchor");
   expect(
-    map.get(`${process.env.CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`)
-      .suggestion
+    map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/API/Blob?a=b`).suggestion
   ).toBe("/en-US/docs/Web/API/Blob?a=b");
   expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
     "/en-US/docs/Web/API/Blob"
@@ -1018,9 +1014,7 @@ test("image flaws kitchen sink", () => {
   expect(flaw.line).toBe(49);
   expect(flaw.column).toBe(13);
 
-  flaw = map.get(
-    `${process.env.CONTENT_ORIGIN}/en-US/docs/Web/Images/screenshot.png`
-  );
+  flaw = map.get(`${CONTENT_ORIGIN}/en-US/docs/Web/Images/screenshot.png`);
   expect(flaw.explanation).toBe("Unnecessarily absolute URL");
   expect(flaw.suggestion).toBe("screenshot.png");
   expect(flaw.line).toBe(54);


### PR DESCRIPTION
this adds `GITHUB_ORG` and `CONTENT_ORIGIN` to `libs/env/index.js` and `client/src/env.ts` which is what's done for other environment variables.