### PR TITLE
Fix build warnings

### DIFF
--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -102,6 +102,10 @@ export const GLEAN_ENABLED = Boolean(
   JSON.parse(process.env.REACT_APP_GLEAN_ENABLED || "false")
 );
 
+export const SURVEYS_ENABLED = Boolean(
+  JSON.parse(process.env.REACT_APP_SURVEYS_ENABLED || "false")
+);
+
 export function survey_duration(surveyBucket: string): {
   start: number;
   end: number;

--- a/client/src/ui/molecules/document-survey/surveys.ts
+++ b/client/src/ui/molecules/document-survey/surveys.ts
@@ -1,5 +1,5 @@
 import { Doc } from "../../../../../libs/types/document";
-import { survey_duration, survey_rates } from "../../../env";
+import { SURVEYS_ENABLED, survey_duration, survey_rates } from "../../../env";
 
 export interface Survey {
   key: SurveyKey;
@@ -43,4 +43,18 @@ enum SurveyKey {
   WEB_SECURITY_2023 = "WEB_SECURITY_2023",
 }
 
-export const SURVEYS: Survey[] = [];
+export const SURVEYS: Survey[] = !SURVEYS_ENABLED
+  ? []
+  : [
+      {
+        key: SurveyKey.BLOG_FEEDBACK_2023,
+        bucket: SurveyBucket.BLOG_FEEDBACK_2023,
+        show: (doc: Doc) => /en-US\/docs\/(Web|Learn)(\/|$)/i.test(doc.mdn_url),
+        src: "https://survey.alchemer.com/s3/7397017/MDN-Blog-user-feedback",
+        teaser:
+          "We recently launched the MDN blog to enrich our platform with valuable content and enhance your experience. To ensure that we are meeting your needs, we would like to hear your thoughts and feedback through a short user satisfaction survey.",
+        question: "How satisfied are you with your experience of the MDN blog?",
+        ...survey_duration(SurveyBucket.BLOG_FEEDBACK_2023),
+        ...survey_rates(SurveyKey.BLOG_FEEDBACK_2023),
+      },
+    ];

--- a/client/src/ui/organisms/top-navigation-main/index.tsx
+++ b/client/src/ui/organisms/top-navigation-main/index.tsx
@@ -25,6 +25,15 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
 
       <Search id="top-nav-search" />
       <ThemeSwitcher />
+
+      {PLUS_IS_ENABLED &&
+        ((!isServer && userData && userData.isAuthenticated && <UserMenu />) ||
+          (userData?.maintenance && <Maintenance />) || (
+            <AuthContainer
+              signInGleanContext={TOP_NAV_ALREADY_SUBSCRIBER}
+              subscribeGleanContext={TOP_NAV_GET_MDN_PLUS}
+            />
+          ))}
     </div>
   );
 };

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -29,7 +29,8 @@ various places, and is used to fetch recent contributions (see
 
 #### Default: `https://developer.mozilla.org`
 
-The Origin (scheme+host+port, with no trailing slash) URL where the docs are being hosted.
+The Origin (scheme+host+port, with no trailing slash) URL where the docs are
+being hosted.
 
 ## Builder
 
@@ -344,6 +345,12 @@ included this value for `geo.country`.
   - Be aware of flipping this between true/false as any persisted metrics,
     events and pings (other than first_run_date and first_run_hour) are cleared.
     [More info](https://mozilla.github.io/glean/book/reference/general/initializing.html#when-upload-is-disabled)
+
+### `REACT_APP_SURVEYS_ENABLED`
+
+**Default: `false`**
+
+If enabled, surveys will be presented on documentation pages.
 
 ### REACT_APP_PLAYGROUND_BASE_HOST
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:ssr": "cd ssr && webpack --mode=production",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
-    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"ğŸ”„ $(pwd)\" && npx tsc --noEmit && echo \"â˜‘ğ¸  $(pwd)\" || exit 255'",
+    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"ğŸ”„ $(pwd)\" && npx tsc --noEmit && echo \"â˜‘ï¸  $(pwd)\" || exit 255'",
     "dev": "yarn build:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",
     "filecheck": "ts-node filecheck/cli.ts",
@@ -141,6 +141,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.8",
     "@babel/eslint-parser": "^7.22.7",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-env": "^7.22.7",
     "@mdn/dinocons": "^0.5.5",
     "@mdn/minimalist": "^2.0.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,12 @@ import { MEMOIZE_INVALIDATE, getRoot } from "../content/utils.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { renderHTML } from "../ssr/dist/main.js";
+import {
+  allPostFrontmatter,
+  findPostLiveSampleBySlug,
+  findPostBySlug,
+  findPostPathBySlug,
+} from "../build/blog.js";
 
 async function buildDocumentFromURL(url: string) {
   const document = Document.findByURL(url);
@@ -230,6 +236,61 @@ app.get("/*/contributors.txt", async (req, res) => {
   );
 });
 
+app.get("/:locale/blog/index.json", async (_, res) => {
+  const posts = await allPostFrontmatter(
+    { includeUnpublished: true },
+    MEMOIZE_INVALIDATE
+  );
+  return res.json({ hyData: { posts } });
+});
+app.get("/:locale/blog/author/:slug/:asset", async (req, res) => {
+  const { slug, asset } = req.params;
+  return send(
+    req,
+    path.resolve(
+      BLOG_ROOT,
+      "..",
+      "authors",
+      sanitizeFilename(slug),
+      sanitizeFilename(asset)
+    )
+  ).pipe(res);
+});
+app.get("/:locale/blog/:slug/index.json", async (req, res) => {
+  const { slug } = req.params;
+  const data = await findPostBySlug(slug);
+  if (!data) {
+    return res.status(404).send("Nothing here 🤷‍♂️");
+  }
+  return res.json(data);
+});
+app.get(
+  ["/:locale/blog/:slug/runner.html", "/:locale/blog/:slug/runner.html"],
+  async (req, res) => {
+    return res
+      .setHeader("Content-Security-Policy", PLAYGROUND_UNSAFE_CSP_VALUE)
+      .status(200)
+      .sendFile(path.join(STATIC_ROOT, "runner.html"));
+  }
+);
+app.get("/:locale/blog/:slug/_sample_.:id.html", async (req, res) => {
+  const { slug, id } = req.params;
+  try {
+    return res.send(await findPostLiveSampleBySlug(slug, id));
+  } catch (e) {
+    return res.status(404).send(e.toString());
+  }
+});
+app.get("/:locale/blog/:slug/:asset", async (req, res) => {
+  const { slug, asset } = req.params;
+  const p = findPostPathBySlug(slug);
+  if (p) {
+    return send(req, path.resolve(path.join(p, sanitizeFilename(asset)))).pipe(
+      res
+    );
+  }
+  return res.status(404).send("Nothing here 🤷‍♂️");
+});
 app.get("/*", async (req, res, ...args) => {
   const parsedUrl = new URL(req.url, `http://localhost:${PORT}`);
   if (req.url.startsWith("/_")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,6 +517,16 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz#af613d2cd5e643643b65cded64207b15c85cb78e"


### PR DESCRIPTION
maybe this will make the CI stop complaining. we're still getting the enigmatic warning

```
Creating an optimized production build...
Compiled with warnings.

DefinePlugin
Conflicting values for 'process.env'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

I think this is related to `dotenv-webpack` but there doesn't seem to be any way of figuring out why exactly this warning is being generated? fun!

---

- add @babel/plugin-proposal-private-property-in-object dev dependency (as suggested by `yarn build:prepare` - it seems two packages currently depend on it but only one actually lists it as a dependency, which might become a problem in the future)
- restore "surveys" from mdn/yari, add env var to enable them (by default they will be disabled)
- restore "AuthContainer" from mdn/yari (only enabled when plus is)
- restore server/index.ts and server/search-index.ts from mdn/yari (no longer relevant to us since we're not hosting with `yarn start:server` anymore (and probably never should have been))