### PR TITLE
Further cleanup of a GITHUB_ORG usage

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -33,8 +33,6 @@ import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
 
-export const GITHUB_ORG = process.env.GITHUB_ORG;
-
 const FEATURED_ARTICLES = [
   "blog/regular-expressions-reference-updates/",
   "blog/aria-accessibility-html-landmark-roles/",


### PR DESCRIPTION
This was already properly removed in https://github.com/webdocs-dev/yari/pull/11, but when I rebased against the latest mdn/content, and was fixing merge conflicts, I inadvertenly reverted this removal. So this re-removes it.