### PR TITLE
Add rustc to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
 
           # Other tools
           git
+          rustc
         ];
       };
     });


### PR DESCRIPTION
Since we've got the Rust script for fixing up filenames for deploy builds, I've added rustc to the Nix flake so it's users can compile the script.