### PR TITLE
Make commit hook do markdown linting

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,4 +2,5 @@ export default {
   "!*.{js,jsx,ts,tsx,css,scss}": "prettier --ignore-unknown --write",
   "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
   "*.{css,scss}": ["stylelint --fix --allow-empty-input", "prettier --write"],
+  "*.md": ["npx markdownlint-cli --fix"],
 };


### PR DESCRIPTION
Fixes https://github.com/webdocs-dev/yari/issues/19. Note that the change in this PR uses the `--fix` (_“fix basic errors”_) option.  Not sure we absolutely want/need that, but having it is consistent with what the current commit hooks run for other file types (js,jsx,ts,tsx,css,scss).