### PR TITLE
set default live sample prefix to `''` rather than SERVER_URL

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -43,21 +43,21 @@ prefixed with `CONTENT_`. E.g. `CONTENT_ROOT`
 
 **Default: `../content/files`**
 
-Path to the content files, cloned from https://github.com/mdn/content.
+Path to the content files, cloned from <https://github.com/mdn/content>.
 
 ### `CONTENT_TRANSLATED_ROOT`
 
 **Default: `../translated-content/files`**
 
 Path to the translated content files, cloned from
-https://github.com/mdn/translated-content.
+<https://github.com/mdn/translated-content>.
 
 ### `CONTRIBUTOR_SPOTLIGHT_ROOT`
 
 **Default: `../mdn-contributor-spotlight/contributors`**
 
 Path to the contributor spotlight content, cloned from
-https://github.com/mdn/mdn-contributor-spotlight.
+<https://github.com/mdn/mdn-contributor-spotlight>.
 
 ### `BUILD_FOLDERSEARCH`
 
@@ -130,19 +130,16 @@ information about fixable flaws instead of actually fixing it on disk.
 
 ### `BUILD_LIVE_SAMPLES_BASE_URL`
 
-**Default: `https://live.mdnplay.dev`**
+**Default: `''`**
 
 When generating live samples `<iframe>` tags, the `src` attribute gets this set
 as a prefix. The ultimate reason why it's meant to be different is because the
 security of the `iframe`'s content has not been audited as carefully as the rest
 of the site.
 
-When doing local development, it's recommended to set this to
-`http://localhost:5042` in your personal `.env`.
-
 ### `BUILD_LEGACY_LIVE_SAMPLES_BASE_URL`
 
-**Default: `https://live-samples.mdn.mozilla.net`**
+**Default: `''`**
 
 Used to serve legacy lives samples that do not support playground rendering.
 
@@ -353,7 +350,7 @@ If enabled, surveys will be presented on documentation pages.
 
 ### REACT_APP_PLAYGROUND_BASE_HOST
 
-**Default: mdnplay.dev**
+**Default: `mdnplay.dev`**
 
 - Sets the host name for the playground iframe. Set this to `localhost:5042`
   when working on playground functionality.

--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -162,9 +162,8 @@ async function renderItem(slug) {
 async function getPageLinkAndTitle(slug) {
   let link = `/${env.locale}${slug}`;
   let page = await wiki.getPage(link);
-
-  if (!page.title && env.locale !== 'en-US') {
-    link = `/en-US${slug}`;
+  if (!page.title && env.locale !== env.defaultLocale) {
+    link = `/${env.defaultLocale}${slug}`;
     page = await wiki.getPage(link);
   }
 

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -70,12 +70,6 @@ if (sampleSlug) {
 }
 var id = web.slugify(web.safeDecodeURIComponent(sampleIdOrOffset));
 var url = await template('LiveSampleURL', [id, sampleUrl]);
-if (url.indexOf("://") !== -1) {
-	// remove protocol and domain name from url
-	// (this is needed for accessing docs through a server-side proxy)
-	url = url.substring(url.indexOf("://") + 3);
-	url = url.substring(url.indexOf("/"));
-}
 
 if (hasScreenshot) {
 %><table class="sample-code-table"><%

--- a/kumascript/src/environment.ts
+++ b/kumascript/src/environment.ts
@@ -45,6 +45,8 @@ import pagePrototype from "./api/page.js";
 import info from "./info.js";
 import Templates from "./templates.js";
 
+import { DEFAULT_LOCALE } from "../../libs/constants/index.js";
+
 export interface KumaThis {
   mdn: typeof mdnPrototype;
   wiki: typeof wikiPrototype;
@@ -139,6 +141,10 @@ export default class Environment {
     const web = Object.create(prepareProto(webPrototype, globals));
     const page = Object.create(prepareProto(pagePrototype, globals));
     const env = Object.create(prepareProto(perPageContext));
+
+    // DEFAULT_LOCALE is identical across all pages,
+    // so we don't need it in perPageContext
+    env.defaultLocale = DEFAULT_LOCALE;
 
     // The page object also gets some properties copied from
     // the per-page context object

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -142,12 +142,12 @@ const SERVER_URL = `http://localhost:${SERVER_PORT}`;
 export const LIVE_SAMPLES_BASE_URL =
   process.env.BUILD_LIVE_SAMPLES_BASE_URL !== undefined
     ? process.env.BUILD_LIVE_SAMPLES_BASE_URL
-    : SERVER_URL;
+    : "";
 
 export const LEGACY_LIVE_SAMPLES_BASE_URL =
   process.env.BUILD_LEGACY_LIVE_SAMPLES_BASE_URL !== undefined
     ? process.env.BUILD_LEGACY_LIVE_SAMPLES_BASE_URL
-    : LIVE_SAMPLES_BASE_URL || SERVER_URL;
+    : LIVE_SAMPLES_BASE_URL || "";
 
 export const INTERACTIVE_EXAMPLES_BASE_URL =
   process.env.BUILD_INTERACTIVE_EXAMPLES_BASE_URL ||


### PR DESCRIPTION
this lets us delete the old hack for fixing live samples, which was causing some kumascript tests to fail

(i don't see any reason to use `SERVER_URL` rather than `''` as the default)

also i'm not sure why the docs said that the default values of `BUILD_LEGACY_LIVE_SAMPLES_BASE_URL` and `BUILD_LIVE_SAMPLES_BASE_URL` were `https://live.mdnplay.dev` and `https://live-samples.mdn.mozilla.net` when that wasn't actually true as far as i can tell...

