### PR TITLE
give github labeler write permission for PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/labeler@v4.3.0
         with:


### PR DESCRIPTION
i think this will fix the problem where the labeler github action is failing

(i've just taken the "permissions" section from the example [here](https://github.com/actions/labeler#create-workflow))

not sure why this isn't a problem for mdn/yari...