### PR TITLE
Suppress ExperimentalWarning messages from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:libs": "yarn jest --rootDir libs --env=node",
     "test:prepare": "yarn build:prepare && yarn build && yarn start:static-server",
     "test:testing": "yarn jest --rootDir testing",
-    "tool": "ts-node tool/cli.ts",
+    "tool": "NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts",
     "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "resolutions": {


### PR DESCRIPTION
This change causes the build to suppress any `ExperimentalWarning` messages that Node reports.

Otherwise — without this change — the build reports many message of the form:

- _ExperimentalWarning: Importing JSON modules is an experimental feature…_
- _ExperimentalWarning: Import assertions are not a stable feature…_