### PR TITLE
Minimal footer for webdocs.dev which removes MDN-specific links

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -2,6 +2,7 @@ CONTENT_ROOT=../content/files
 #CONTENT_TRANSLATED_ROOT=../translated-content/files
 #CONTRIBUTOR_SPOTLIGHT_ROOT=../mdn-contributor-spotlight/contributors
 
+REACT_APP_ORGANIZATION=webdocs.dev
 REACT_APP_BCD_BASE_URL=https://bcd.webdocs.dev
 REACT_APP_CONTENT_ORIGIN=https://webdocs.dev
 REACT_APP_DEFAULT_LOCALE=en-us

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -8,6 +8,8 @@ export const DISABLE_AUTH = Boolean(
   JSON.parse(process.env.REACT_APP_DISABLE_AUTH || "false")
 );
 
+export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";
+
 /** Deprecated, don't export, use WRITER_MODE and/or DEV_MODE instead. */
 const CRUD_MODE =
   process.env.REACT_APP_WRITER_MODE || process.env.REACT_APP_DEV_MODE

--- a/client/src/homepage/contributor-spotlight/index.tsx
+++ b/client/src/homepage/contributor-spotlight/index.tsx
@@ -29,25 +29,21 @@ export function ContributorSpotlight(props: HydrationData<any>) {
     }
   );
 
-  return (
+  return hyData && hyData?.featuredContributor ? (
     <div className="contributor-spotlight dark">
       <div className="wrapper">
         <div className="text-col">
           <h3>Contributor Spotlight</h3>
-          {hyData && hyData?.featuredContributor && (
-            <>
-              <a
-                className="contributor-name"
-                href={hyData?.featuredContributor?.url}
-              >
-                {hyData?.featuredContributor?.contributorName}
-              </a>
-              <blockquote>
-                <Icon name="quote"></Icon>
-                {hyData?.featuredContributor?.quote}
-              </blockquote>
-            </>
-          )}
+          <a
+            className="contributor-name"
+            href={hyData?.featuredContributor?.url}
+          >
+            {hyData?.featuredContributor?.contributorName}
+          </a>
+          <blockquote>
+            <Icon name="quote"></Icon>
+            {hyData?.featuredContributor?.quote}
+          </blockquote>
           <a href="/en-US/community" className="spotlight-cta">
             Get involved →
           </a>
@@ -63,5 +59,5 @@ export function ContributorSpotlight(props: HydrationData<any>) {
       </div>
       <Mandala />
     </div>
-  );
+  ) : null;
 }

--- a/client/src/homepage/index.tsx
+++ b/client/src/homepage/index.tsx
@@ -5,6 +5,7 @@ import { LatestNews } from "./latest-news";
 import RecentContributions from "./recent-contributions";
 import { ContributorSpotlight } from "./contributor-spotlight";
 import { HpFooterPlacement, HpMainPlacement } from "../ui/organisms/placement";
+import { BLOG_IS_ENABLED } from "../env";
 
 export function Homepage(props) {
   return (
@@ -13,7 +14,7 @@ export function Homepage(props) {
         <HomepageHero />
         <HpMainPlacement />
         <FeaturedArticles {...props} />
-        <LatestNews {...props} />
+        {BLOG_IS_ENABLED && <LatestNews {...props} />}
         <RecentContributions {...props} />
         <ContributorSpotlight {...props} />
         <HpFooterPlacement />

--- a/client/src/homepage/recent-contributions/index.tsx
+++ b/client/src/homepage/recent-contributions/index.tsx
@@ -28,7 +28,7 @@ function RecentContributions(props: HydrationData<any>) {
     }
   );
 
-  return hyData?.recentContributions ? (
+  return hyData?.recentContributions?.items ? (
     <section className="recent-contributions">
       <h2>Recent contributions</h2>
       <ul className="contribution-list">

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -4,17 +4,38 @@ import { useLocation } from "react-router-dom";
 
 import { ReactComponent as MDNLogo } from "../../../assets/mdn-footer-logo.svg";
 import { ReactComponent as MozLogo } from "../../../assets/moz-logo.svg";
-import { PLUS_IS_ENABLED, BLOG_IS_ENABLED } from "../../../env";
+import { PLUS_IS_ENABLED, BLOG_IS_ENABLED, ORGANIZATION } from "../../../env";
 const DARK_NAV_ROUTES = [/\/plus\/?$/i];
 
-export function Footer() {
+function Copyright() {
   const locale = useLocale();
+
+  return (
+    <>
+      Portions of this content are ©1998–{new Date().getFullYear()} by
+      individual contributors. Content available under{" "}
+      <a
+        href={`/${locale}/docs/MDN/Writing_guidelines/Attrib_copyright_license`}
+      >
+        a Creative Commons license
+      </a>
+      .
+    </>
+  );
+}
+
+function useFooterClass() {
   const location = useLocation();
   const route = location.pathname.substring(location.pathname.indexOf("/", 1));
   const dark = DARK_NAV_ROUTES.some((r) => route.match(r));
+  return `page-footer${dark ? " dark" : ""}`;
+}
+
+function MDNFooter() {
+  const locale = useLocale();
 
   return (
-    <footer id="nav-footer" className={`page-footer${dark ? " dark" : ""}`}>
+    <footer id="nav-footer" className={useFooterClass()}>
       <div className="page-footer-grid">
         <div className="page-footer-logo-col">
           <a href="/" className="mdn-footer-logo" aria-label="MDN homepage">
@@ -35,22 +56,24 @@ export function Footer() {
             <li>
               <a
                 className="icon icon-github-mark-small"
-                href={`https://github.com/mdn`}
+                href="https://github.com/mdn"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 <span className="visually-hidden">MDN on GitHub</span>
               </a>
             </li>
-            <li>
-              <a
-                className="icon icon-feed"
-                href="/en-US/blog/rss.xml"
-                target="_blank"
-              >
-                <span className="visually-hidden">MDN Blog RSS Feed</span>
-              </a>
-            </li>
+            {BLOG_IS_ENABLED && (
+              <li>
+                <a
+                  className="icon icon-feed"
+                  href="/en-US/blog/rss.xml"
+                  target="_blank"
+                >
+                  <span className="visually-hidden">MDN Blog RSS Feed</span>
+                </a>
+              </li>
+            )}
           </ul>
         </div>
 
@@ -239,17 +262,103 @@ export function Footer() {
             </a>
             .
             <br />
-            Portions of this content are ©1998–{new Date().getFullYear()} by
-            individual mozilla.org contributors. Content available under{" "}
-            <a
-              href={`/${locale}/docs/MDN/Writing_guidelines/Attrib_copyright_license`}
-            >
-              a Creative Commons license
-            </a>
-            .
+            <Copyright />
           </p>
         </div>
       </div>
     </footer>
   );
+}
+
+function WebdocsDevFooter() {
+  const locale = useLocale();
+
+  return (
+    <footer id="nav-footer" className={useFooterClass()}>
+      <div className="page-footer-grid">
+        <div className="page-footer-logo-col">
+          <a
+            href="/"
+            className="mdn-footer-logo"
+            aria-label="webdocs.dev homepage"
+          >
+            webdocs.dev
+          </a>
+          <ul className="social-icons">
+            <li>
+              <a
+                className="icon icon-github-mark-small"
+                href="https://github.com/webdocs-dev"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="visually-hidden">GitHub</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div className="page-footer-nav-col-1">
+          <h2 className="footer-nav-heading">Support</h2>
+          <ul className="footer-nav-list">
+            <li className="footer-nav-item">
+              <a
+                className="footer-nav-link"
+                href={`/${locale}/docs/MDN/Community/Issues`}
+              >
+                Report an issue
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div className="page-footer-nav-col-2">
+          <h2 className="footer-nav-heading">Our communities</h2>
+          <ul className="footer-nav-list">
+            <li className="footer-nav-item">
+              <a
+                className="footer-nav-link"
+                href="https://discord.gg/Yqg6TYDzss"
+              >
+                Discord
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div className="page-footer-nav-col-3">
+          <h2 className="footer-nav-heading">Developers</h2>
+          <ul className="footer-nav-list">
+            <li className="footer-nav-item">
+              <a className="footer-nav-link" href={`/${locale}/docs/Web`}>
+                Web Technologies
+              </a>
+            </li>
+            <li className="footer-nav-item">
+              <a className="footer-nav-link" href={`/${locale}/docs/Learn`}>
+                Learn Web Development
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div className="page-footer-legal">
+          <p id="license" className="page-footer-legal-text">
+            <Copyright />
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export function Footer() {
+  switch (ORGANIZATION) {
+    case "mdn":
+      return <MDNFooter />;
+    case "webdocs.dev":
+      return <WebdocsDevFooter />;
+    default:
+      return null;
+  }
 }

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -360,3 +360,10 @@ If enabled, surveys will be presented on documentation pages.
 
 - Sets the host name for the playground iframe. Set this to `localhost:5042`
   when working on playground functionality.
+
+### REACT_APP_ORGANIZATION
+
+**Default: `"mdn"`**
+
+The organization which is hosting the docs — this determines which links are
+displayed in the footer, etc. Acceptable values are `"mdn"` and `"webdocs.dev"`.


### PR DESCRIPTION
Also cleaned up the homepage a bit by removing sections whose contents are empty.

Once we have a logo, we can replace the "webdocs.dev" text with it.