### PR TITLE
Restore cloud-function/package-lock.json to is mdn/yari state

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -623,40 +623,24 @@
       }
     },
     "node_modules/@yari-internal/constants": {
-      "version": "0.0.1",
-      "resolved": "file:src/internal/constants",
-      "license": "MPL-2.0"
+      "resolved": "src/internal/constants",
+      "link": true
     },
     "node_modules/@yari-internal/fundamental-redirects": {
-      "version": "0.0.1",
-      "resolved": "file:src/internal/fundamental-redirects",
-      "license": "MPL-2.0"
+      "resolved": "src/internal/fundamental-redirects",
+      "link": true
     },
     "node_modules/@yari-internal/locale-utils": {
-      "version": "0.0.1",
-      "resolved": "file:src/internal/locale-utils",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "accept-language-parser": "^1.5.0",
-        "cookie": "^0.5.0"
-      }
+      "resolved": "src/internal/locale-utils",
+      "link": true
     },
     "node_modules/@yari-internal/pong": {
-      "version": "0.0.1",
-      "resolved": "file:src/internal/pong",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@adzerk/decision-sdk": "^1.0.0-beta.20",
-        "he": "^1.2.0"
-      }
+      "resolved": "src/internal/pong",
+      "link": true
     },
     "node_modules/@yari-internal/slug-utils": {
-      "version": "0.0.1",
-      "resolved": "file:src/internal/slug-utils",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "sanitize-filename": "^1.6.3"
-      }
+      "resolved": "src/internal/slug-utils",
+      "link": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -3545,13 +3529,11 @@
     "src/internal/constants": {
       "name": "@yari-internal/constants",
       "version": "0.0.1",
-      "extraneous": true,
       "license": "MPL-2.0"
     },
     "src/internal/fundamental-redirects": {
       "name": "@yari-internal/fundamental-redirects",
       "version": "0.0.1",
-      "extraneous": true,
       "license": "MPL-2.0"
     },
     "src/internal/libs/constants": {
@@ -3575,7 +3557,6 @@
     "src/internal/locale-utils": {
       "name": "@yari-internal/locale-utils",
       "version": "0.0.1",
-      "extraneous": true,
       "license": "MPL-2.0",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
@@ -3585,7 +3566,6 @@
     "src/internal/pong": {
       "name": "@yari-internal/pong",
       "version": "0.0.1",
-      "extraneous": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@adzerk/decision-sdk": "^1.0.0-beta.20",
@@ -3595,7 +3575,6 @@
     "src/internal/slug-utils": {
       "name": "@yari-internal/slug-utils",
       "version": "0.0.1",
-      "extraneous": true,
       "license": "MPL-2.0",
       "dependencies": {
         "sanitize-filename": "^1.6.3"


### PR DESCRIPTION
We inadvertently introduced changes to `cloud-function/package-lock.json` in ebba2f1515be3b9966e505d7dc5df88de83db9e0. This change reverts those.

I suspect I may have caused this when I rebased our changes against mdn/yari and then resolved the merge conflicts.