### PR TITLE
Suppress ExperimentalWarning messages from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'client/build/static/js/*.js'",
     "analyze:css": "source-map-explorer 'client/build/static/css/*.css'",
-    "build": "cross-env NODE_ENV=production ts-node build/cli.ts",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node build/cli.ts",
     "build:blog": "cross-env NODE_ENV=production ts-node build/build-blog.ts",
     "build:client": "cd client && cross-env NODE_ENV=production BABEL_ENV=production INLINE_RUNTIME_CHUNK=false node scripts/build.js",
     "build:dist": "tsc -p tsconfig.dist.json",


### PR DESCRIPTION
This change two ExperimentalWarning messages that get reported when running `yarn build`.

Otherwise — without this change — `yarn build` reports these two messages:

- _ExperimentalWarning: Importing JSON modules is an experimental feature…_
- _ExperimentalWarning: Import assertions are not a stable feature…_