### PR TITLE
remove duplicate definition of ORGANIZATION

### DIFF
--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -173,4 +173,3 @@ export const FAKE_V1_API = JSON.parse(process.env.SERVER_FAKE_V1_API || false);
 export const SAMPLE_SIGN_KEY = process.env.BUILD_SAMPLE_SIGN_KEY
   ? Buffer.from(process.env.BUILD_SAMPLE_SIGN_KEY, "base64")
   : null;
-export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";


### PR DESCRIPTION
this accidentally got defined twice because it was added in two different branches
