### PR TITLE
Use uppercase “MDN” for ORGANIZATION; use ORGANIZATION in writer toolbar

### DIFF
--- a/build/page-title.ts
+++ b/build/page-title.ts
@@ -2,11 +2,6 @@ import { Document } from "../content/index.js";
 import { Doc } from "../libs/types/document.js";
 import { ORGANIZATION } from "../libs/env/index.js";
 
-const TITLE_SUFFIX: Map<string, string> = new Map([
-  ["mdn", "MDN"],
-  ["webdocs.dev", "webdocs.dev"],
-]);
-
 /**
  * Return the appropriate document title to go into the HTML <title>
  * tag on the final HTML.
@@ -29,10 +24,10 @@ export function getPageTitle(doc: Partial<Doc>) {
       title += ` - ${parentDoc.metadata.title}`;
     }
   }
-  const suffix = TITLE_SUFFIX.get(ORGANIZATION);
+  const suffix = ORGANIZATION;
   if (!suffix) {
     throw new Error(
-      `TITLE_SUFFIX["${ORGANIZATION}"] is not defined. Make sure the value of REACT_APP_ORGANIZATION is correct.`
+      `${ORGANIZATION} is not defined. Make sure the value of REACT_APP_ORGANIZATION is correct.`
     );
   }
   return `${title} | ${suffix}`;

--- a/client/config/env.js
+++ b/client/config/env.js
@@ -40,11 +40,11 @@ process.env.NODE_PATH = (process.env.NODE_PATH || "")
 // injected into the application via DefinePlugin in webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
-const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";
+const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "MDN";
 
 // the name of the site as a human-readable string
 const SITE_NAMES = new Map([
-  ["mdn", "MDN Web Docs"],
+  ["MDN", "MDN Web Docs"],
   ["webdocs.dev", "webdocs.dev"],
 ]);
 

--- a/client/config/env.js
+++ b/client/config/env.js
@@ -66,6 +66,7 @@ function getClientEnvironment(publicUrl) {
         NODE_ENV: process.env.NODE_ENV || "development",
         SITE_NAME: siteName,
         ORGANIZATION,
+        SOCIAL_SHARE_IMAGE: ORGANIZATION.toLowerCase() + "-social-share.png",
         CONTENT_ORIGIN:
           process.env.REACT_APP_CONTENT_ORIGIN ||
           "https://developer.mozilla.org",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -57,7 +57,7 @@
       property="og:description"
       content="The %SITE_NAME% site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."
     />
-    <meta property="og:image" content="%ORGANIZATION%-social-share.png" />
+    <meta property="og:image" content="%SOCIAL_SHARE_IMAGE%" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="MozDevNet" />
 

--- a/client/scripts/build-favicons.js
+++ b/client/scripts/build-favicons.js
@@ -1,8 +1,8 @@
 import sharp from "sharp";
 
-const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";
+const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "MDN";
 const ICONS = new Map([
-  ["mdn", "src/assets/m-icon.svg"],
+  ["MDN", "src/assets/m-icon.svg"],
   ["webdocs.dev", "src/assets/webdocs-dev-icon.svg"],
 ]);
 

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { WRITER_MODE_HOSTNAMES, CONTENT_ORIGIN } from "../../env";
+import { WRITER_MODE_HOSTNAMES, CONTENT_ORIGIN, ORGANIZATION } from "../../env";
 import { Source } from "../../../../libs/types/document";
 
 import "./edit-actions.scss";
@@ -79,7 +79,7 @@ export function EditActions({ source }: { source: Source }) {
 
       <li>
         <a href={`${CONTENT_ORIGIN}/${locale}/docs/${slug}`} className="button">
-          View on MDN
+          View on {ORGANIZATION}
         </a>
       </li>
 

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -8,7 +8,7 @@ export const DISABLE_AUTH = Boolean(
   JSON.parse(process.env.REACT_APP_DISABLE_AUTH || "false")
 );
 
-export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";
+export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "MDN";
 
 /** Deprecated, don't export, use WRITER_MODE and/or DEV_MODE instead. */
 const CRUD_MODE =

--- a/client/src/homepage/homepage-hero/index.tsx
+++ b/client/src/homepage/homepage-hero/index.tsx
@@ -13,7 +13,7 @@ export function HomepageHero() {
         </h1>
         <p>
           Documenting web technologies, including CSS, HTML, and JavaScript
-          {ORGANIZATION === "mdn" && <>, since 2005</>}.
+          {ORGANIZATION === "MDN" && <>, since 2005</>}.
         </p>
         <Search id="hp-search" isHomepageSearch={true} />
       </section>

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -354,7 +354,7 @@ function WebdocsDevFooter() {
 
 export function Footer() {
   switch (ORGANIZATION) {
-    case "mdn":
+    case "MDN":
       return <MDNFooter />;
     case "webdocs.dev":
       return <WebdocsDevFooter />;

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -363,10 +363,10 @@ If enabled, surveys will be presented on documentation pages.
 
 ### `REACT_APP_ORGANIZATION`
 
-**Default: `"mdn"`**
+**Default: `"MDN"`**
 
 The organization which is hosting the docs — this determines which links are
-displayed in the footer, etc. Acceptable values are `"mdn"` and `"webdocs.dev"`.
+displayed in the footer, etc. Acceptable values are `"MDN"` and `"webdocs.dev"`.
 
 ### `REACT_APP_SEARCH_BACKEND`
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -87,7 +87,7 @@ export const BLOG_IS_ENABLED = JSON.parse(
 
 export const CONTENT_ORIGIN =
   process.env.REACT_APP_CONTENT_ORIGIN || "https://developer.mozilla.org";
-export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "mdn";
+export const ORGANIZATION = process.env.REACT_APP_ORGANIZATION || "MDN";
 
 // This makes it possible to know, give a root folder, what is the name of
 // the repository on GitHub.


### PR DESCRIPTION
We need uppercase “MDN” for “View on webdocs.dev”/“View on MDN” writer’s toolbar that’s shown above every article title when `REACT_APP_WRITER_MODE` is true. And that best way to get that from our existing config/enviroment setting is with the `ORGANIZATION` value. And we may end up having other cases where we want to show the configurable organization name in its normal case state.

And while it’s true that we also have potential use for an organization name in github.com URLs, the “webdocs.dev” `ORGANIZATION` name is anyway not the same as the “webdocs-dev” _GitHub_ organization. So if we ever need to have lowercase “mdn” for github.com repo URLs or whatever, then we are going to need to have another environment variable for that anyway — `GITHUB_ORGANIZATION`, or whatever.